### PR TITLE
Add support for reading .env file

### DIFF
--- a/stack-deploy.sh
+++ b/stack-deploy.sh
@@ -11,6 +11,10 @@ elif [ ! -f "${HOME}/.docker/config.json" ]; then
   ln -sfn /auth.json "${HOME}/.docker/config.json"
 fi
 
+if [ -f /.env ]; then
+  export $(grep -v '^\s*#' /.env | grep '=' | xargs -0)
+fi
+
 deploy_prefix="${STACK_NAME}-interim" docker stack deploy --with-registry-auth -c "${STACK_FILE}" "${STACK_NAME}"
 
 docker secret ls --format "table {{.ID}}\t{{.Name}}" \

--- a/stack-deploy.sh
+++ b/stack-deploy.sh
@@ -11,8 +11,8 @@ elif [ ! -f "${HOME}/.docker/config.json" ]; then
   ln -sfn /auth.json "${HOME}/.docker/config.json"
 fi
 
-if [ -f /.env ]; then
-  export $(grep -v '^\s*#' /.env | grep '=' | xargs -0)
+if [ -f .env ]; then
+  export $(grep -v '^\s*#' .env | grep '=' | xargs -0)
 fi
 
 deploy_prefix="${STACK_NAME}-interim" docker stack deploy --with-registry-auth -c "${STACK_FILE}" "${STACK_NAME}"


### PR DESCRIPTION
`docker stack deploy` reads exported environment variables but it will not try to load environment variables from a `.env` file like docker-compose. This pull request checks for an `.env` file and, if one exists, exports all of the variables in it before running the stack deploy.