### PR TITLE
Add support for updates to volumes

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,7 @@ docker run --rm \
   -e "STACK_FILE=/app/docker-stack.yml" \
   kelvineducation/stack-deploy
 ```
+
+stack-deploy makes a few environment variables available to your docker-stack.yml:
+ - `deploy_prefix`: every secret and config name should prepended with this variable so that when the secret or config is changed, stack-deploy can swap in the updated secrets and configs.  Swarm Mode does not natively support updating secrets or configs in place, so stack-deploy supplements this functionality by temporarily releasing the secrets and configs with an interim name, deleting the secrets and configs with the original name, and then re-releasing the updated secrets and configs with the updated name.
+ - `time_suffix`: every volume name should be prepended with this variable so that when a deploy is made that should trigger changes to a volume, a new volume will be created.  Docker only copies to volumes from containers when first creating a volume, so stack-deploy supplements this functionality by providing this variable to force a new volume name.  Additionally, you can set the following label on volumes to have the unused volumes periodically pruned: `education.kelvin.prune=stack-deploy`

--- a/stack-deploy.sh
+++ b/stack-deploy.sh
@@ -11,6 +11,8 @@ elif [ ! -f "${HOME}/.docker/config.json" ]; then
   ln -sfn /auth.json "${HOME}/.docker/config.json"
 fi
 
+export time_prefix="${STACK_NAME}-$(date +%s)"
+
 deploy_prefix="${STACK_NAME}-interim" docker stack deploy --with-registry-auth -c "${STACK_FILE}" "${STACK_NAME}"
 
 docker secret ls --format "table {{.ID}}\t{{.Name}}" \
@@ -32,3 +34,5 @@ docker config ls --format "table {{.ID}}\t{{.Name}}" \
   | grep -E "\s+${STACK_NAME}-interim" \
   | awk '{print $1}' \
   | xargs -I {} docker config rm {}
+
+docker volume prune --force --filter 'label=education.kelvin.prune=stack-deploy'


### PR DESCRIPTION
When using nginx with php-fpm, almost always there will be a codebase that needs to be shared between the two containers. Using a named volume that both containers share is the most straightforward way to accomplish this.

However, once the volume is created, future `docker stack deploy`s will re-use the existing volume without copying in the new codebase. Generally a deploy is going to result in a codebase change, so re-using the existing volume does not make sense. Getting the `docker stack deploy` to create a new volume is simple: change the name of the volume so a new volume must be created.

This PR adds a `time_suffix` environment variable that `docker-stack.yml` files can prefix to volume names to cause a new volume to be created during each `docker stack deploy`. With this change, unused volumes with a label of `education.kelvin.prune=stack-deploy` are periodically pruned so that volume cleanup can be configured to be automatic.