### PR TITLE
Wait for deploy to finish before exiting

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
 FROM alpine:3.8
 
-RUN apk add --no-cache docker \
+RUN apk add --no-cache docker bash \
   && rm /usr/bin/docker?*
 
 RUN echo '{}' >/auth.json
 
 COPY stack-deploy.sh /stack-deploy.sh
 
-CMD ["/stack-deploy.sh"]
+ENTRYPOINT ["/stack-deploy.sh"]
+CMD ["deploy"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+.PHONY: tests
+
+tests:
+	bash tests.sh

--- a/stack-deploy.sh
+++ b/stack-deploy.sh
@@ -1,6 +1,27 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
+set -u
+
+if [ "${1:-deploy}" != "deploy" ]; then
+  exec "${@}"
+fi
+
+detach=0
+debug=0
+for opt in "${@}"; do
+  case "${opt}" in
+    --detach)
+      detach=1
+      ;;
+
+    --debug)
+      debug=1
+      ;;
+  esac
+done
+
+[ $debug -eq 1 ] && set -x
 
 if [ "${HOME}" == "" ]; then
   echo "\$HOME is empty. Docker registry credentials will be unavailable." >&2
@@ -40,3 +61,50 @@ docker config ls --format "table {{.ID}}\t{{.Name}}" \
   | xargs -I {} docker config rm {}
 
 docker volume prune --force --filter 'label=education.kelvin.prune=stack-deploy'
+
+[ $detach -eq 1 ] && exit
+
+echo -n "Waiting for deploy to complete... "
+
+service_count=$(docker stack services -q "${STACK_NAME}" | wc -l)
+service_ids=($(docker stack services -q "${STACK_NAME}"))
+
+failed_count=0
+completed_count=0
+while [ $completed_count -lt $service_count ]; do
+  failed_count=0
+  completed_count=0
+
+  statuses=($(docker service inspect --format '{{if .UpdateStatus}}{{.UpdateStatus.State}}{{end}}' "${service_ids[@]}"))
+  for status in "${statuses[@]}"; do
+    case "${status}" in
+      *paused | rollback_completed)
+        failed_count=$((failed_count + 1))
+        completed_count=$((completed_count + 1))
+        ;;
+
+      completed)
+        completed_count=$((completed_count + 1))
+        ;;
+    esac
+  done
+
+  usleep 500000
+done
+
+if [ $failed_count -ne 0 ]; then
+  echo "failed"
+  echo "One or more services failed to deploy"
+  exit 1
+fi
+
+echo "completed"
+
+# possible swarm service status keys:
+# https://github.com/moby/moby/blob/8e610b2b55bfd1bfa9436ab110d311f5e8a74dcb/api/types/swarm/service.go#L43
+# - updating
+# - paused
+# - completed
+# - rollback_started
+# - rollback_paused
+# - rollback_completed

--- a/stack-deploy.sh
+++ b/stack-deploy.sh
@@ -85,10 +85,13 @@ determine_status() {
   # strip off `actual_count/`
   expected="${replicas#*/}"
 
+  local zero_status="new"
+  [ $expected -eq 0 ] && zero_status="completed"
+
   task_ids=($(docker service ps -q --filter 'desired-state=running' "${service_id}"))
-  [ ${#task_ids[@]} -eq 0 ] && status="new" && return
+  [ ${#task_ids[@]} -eq 0 ] && status="${zero_status}" && return
   container_ids=($(docker inspect --format '{{.Status.ContainerStatus.ContainerID}}' "${task_ids[@]}"))
-  [ ${#container_ids[@]} -eq 0 ] && status="new" && return
+  [ ${#container_ids[@]} -eq 0 ] && status="${zero_status}" && return
   started_ats=($(
     docker inspect --format '{{if .State.Running}}{{.State.StartedAt}}{{end}}' "${container_ids[@]}" \
       | sed -E 's/(\d{4}-\d{2}-\d{2})T(\d{2}:\d{2}:\d{2})\.\d+Z/\1 \2/' \

--- a/tests.sh
+++ b/tests.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+docker build -q -t kelvineducation/stack-deploy:test . || exit $?
+
+has_failures=0
+
+run_test() {
+  local timestamp=$(date +%s)
+  local test_name="${1}"
+  local stack_name="test-${test_name}-${timestamp}"
+
+  local expected_exit=$(sed -E '/^Exit code: ([0-9]+)/c \1' "tests/${test_name}.expected.txt")
+
+  echo -n "Running ${test_name}... "
+
+  STACK_FILE="${test_name}.stack.yml" \
+    STACK_NAME="${stack_name}" \
+    docker-compose -f tests/stack-deploy.yml run --rm stack-deploy >/dev/null
+
+  local actual_exit="$?"
+
+  if [ $actual_exit -ne $expected_exit ]; then
+    echo "failed. Exited with exit code ${actual_exit} (expected ${expected_exit})."
+    has_failures=1
+  else
+    echo "succeeded"
+  fi
+
+  docker stack rm "${stack_name}" >/dev/null
+}
+
+run_test "initially-broken"
+
+[ $has_failures -eq 0 ] \
+  && echo "All tests passed successfully" \
+  || echo "One or more tests failed"
+
+exit $has_failures

--- a/tests.sh
+++ b/tests.sh
@@ -4,6 +4,17 @@ docker build -q -t kelvineducation/stack-deploy:test . || exit $?
 
 has_failures=0
 
+deploy() {
+  stack_file="${1}"
+  stack_name="${2}"
+
+  STACK_FILE="${stack_file}" \
+    STACK_NAME="${stack_name}" \
+    docker-compose -f tests/stack-deploy.yml run --rm stack-deploy >/dev/null
+
+  return $?
+}
+
 run_test() {
   local timestamp=$(date +%s)
   local test_name="${1}"
@@ -11,12 +22,22 @@ run_test() {
 
   local expected_exit=$(sed -E '/^Exit code:/s/^.*([0-9]+)$/\1/' "tests/${test_name}.expected.txt")
 
-  echo -n "Running ${test_name}... "
+  echo -n "Running '${test_name}'... "
 
-  STACK_FILE="${test_name}.stack.yml" \
-    STACK_NAME="${stack_name}" \
-    docker-compose -f tests/stack-deploy.yml run --rm stack-deploy >/dev/null
+  local setup_stack="${test_name}.setup.yml"
+  local setup_exit=0
+  if [ -f "${setup_stack}" ]; then
+    deploy "${setup_stack}" "${stack_name}"
+    setup_exit=$?
 
+    if [ $setup_exit -ne 0 ]; then
+      echo "setup failed. Setup stack deploy exited with code ${setup_exit}."
+      has_failures=1
+      return
+    fi
+  fi
+
+  deploy "${test_name}.stack.yml" "${stack_name}"
   local actual_exit="$?"
 
   if [ $actual_exit -ne $expected_exit ]; then
@@ -29,7 +50,11 @@ run_test() {
   docker stack rm "${stack_name}" >/dev/null
 }
 
+run_test "works"
+run_test "update-works"
 run_test "initially-broken"
+run_test "becomes-broken"
+
 
 [ $has_failures -eq 0 ] \
   && echo "All tests passed successfully" \

--- a/tests.sh
+++ b/tests.sh
@@ -9,7 +9,7 @@ run_test() {
   local test_name="${1}"
   local stack_name="test-${test_name}-${timestamp}"
 
-  local expected_exit=$(sed -E '/^Exit code: ([0-9]+)/c \1' "tests/${test_name}.expected.txt")
+  local expected_exit=$(sed -E '/^Exit code:/s/^.*([0-9]+)$/\1/' "tests/${test_name}.expected.txt")
 
   echo -n "Running ${test_name}... "
 

--- a/tests.sh
+++ b/tests.sh
@@ -5,8 +5,8 @@ docker build -q -t kelvineducation/stack-deploy:test . || exit $?
 has_failures=0
 
 deploy() {
-  stack_file="${1}"
-  stack_name="${2}"
+  local stack_file="${1}"
+  local stack_name="${2}"
 
   STACK_FILE="${stack_file}" \
     STACK_NAME="${stack_name}" \

--- a/tests/becomes-broken.expected.txt
+++ b/tests/becomes-broken.expected.txt
@@ -1,0 +1,1 @@
+Exit code: 1

--- a/tests/becomes-broken.setup.yml
+++ b/tests/becomes-broken.setup.yml
@@ -4,11 +4,11 @@ services:
     image: alpine
     command: ["sleep", "60"]
     deploy:
-      replicas: 2
+      replicas: 1
   failure:
     image: alpine
-    command: ["false"]
+    command: ["sleep", "60"]
     deploy:
-      replicas: 2
+      replicas: 1
       restart_policy:
         max_attempts: 3

--- a/tests/becomes-broken.stack.yml
+++ b/tests/becomes-broken.stack.yml
@@ -4,11 +4,11 @@ services:
     image: alpine
     command: ["sleep", "60"]
     deploy:
-      replicas: 2
+      replicas: 1
   failure:
     image: alpine
     command: ["false"]
     deploy:
-      replicas: 2
+      replicas: 1
       restart_policy:
         max_attempts: 3

--- a/tests/begins-working.expected.txt
+++ b/tests/begins-working.expected.txt
@@ -1,0 +1,2 @@
+Exit code: 0
+Setup exit: 1

--- a/tests/begins-working.setup.yml
+++ b/tests/begins-working.setup.yml
@@ -1,0 +1,14 @@
+version: '3.5'
+services:
+  success:
+    image: alpine
+    command: ["sleep", "60"]
+    deploy:
+      replicas: 1
+  failure:
+    image: alpine
+    command: ["false"]
+    deploy:
+      replicas: 1
+      restart_policy:
+        max_attempts: 3

--- a/tests/begins-working.stack.yml
+++ b/tests/begins-working.stack.yml
@@ -1,0 +1,14 @@
+version: '3.5'
+services:
+  success:
+    image: alpine
+    command: ["sleep", "60"]
+    deploy:
+      replicas: 1
+  failure:
+    image: alpine
+    command: ["sleep", "60"]
+    deploy:
+      replicas: 1
+      restart_policy:
+        max_attempts: 3

--- a/tests/initially-broken.expected.txt
+++ b/tests/initially-broken.expected.txt
@@ -1,0 +1,1 @@
+Exit code: 1

--- a/tests/initially-broken.stack.yml
+++ b/tests/initially-broken.stack.yml
@@ -1,0 +1,16 @@
+version: '3.5'
+services:
+  success:
+    image: alpine
+    command: ["sleep", "60"]
+    deploy:
+      replicas: 2
+  failure:
+    image: alpine
+    command: ["false"]
+    deploy:
+      replicas: 2
+      restart_policy:
+        max_attempts: 3
+      update_config:
+        monitor: 4s

--- a/tests/stack-deploy.yml
+++ b/tests/stack-deploy.yml
@@ -1,0 +1,11 @@
+version: '3.5'
+services:
+  stack-deploy:
+    image: kelvineducation/stack-deploy:test
+    networks: []
+    volumes:
+      - .:/app
+      - /var/run/docker.sock:/var/run/docker.sock
+    environment:
+      STACK_NAME: ${STACK_NAME}
+      STACK_FILE: /app/${STACK_FILE}

--- a/tests/update-works.expected.txt
+++ b/tests/update-works.expected.txt
@@ -1,0 +1,1 @@
+Exit code: 0

--- a/tests/update-works.setup.yml
+++ b/tests/update-works.setup.yml
@@ -1,0 +1,7 @@
+version: '3.5'
+services:
+  success:
+    image: alpine
+    command: ["sleep", "60"]
+    deploy:
+      replicas: 2

--- a/tests/update-works.stack.yml
+++ b/tests/update-works.stack.yml
@@ -1,0 +1,7 @@
+version: '3.5'
+services:
+  success:
+    image: alpine
+    command: ["sleep", "60"]
+    deploy:
+      replicas: 3

--- a/tests/works.expected.txt
+++ b/tests/works.expected.txt
@@ -1,0 +1,1 @@
+Exit code: 0

--- a/tests/works.stack.yml
+++ b/tests/works.stack.yml
@@ -1,0 +1,7 @@
+version: '3.5'
+services:
+  success:
+    image: alpine
+    command: ["sleep", "60"]
+    deploy:
+      replicas: 2

--- a/tests/works.stack.yml
+++ b/tests/works.stack.yml
@@ -5,3 +5,9 @@ services:
     command: ["sleep", "60"]
     deploy:
       replicas: 2
+
+  none:
+    image: alpine
+    command: ["sleep", "60"]
+    deploy:
+      replicas: 0


### PR DESCRIPTION
Previously the stack-deploy container would run the `docker stack deploy` command and then exit since `docker stack deploy` is asynchronous. In most cases, we are going to want to know whether the stack was deployed successfully. This pull request adds polling to the stack-deploy process to check whether the stack is successfully deployed or not.